### PR TITLE
feat: expand about section

### DIFF
--- a/about/about.html
+++ b/about/about.html
@@ -1,0 +1,97 @@
+<!doctype html>
+<html lang="ru">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Обо мне</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="../styles.css" />
+  </head>
+  <body>
+    <header class="top-bar">
+      <div class="container">
+        <div class="logo">Адвокат в Москве</div>
+        <nav class="main-nav">
+          <ul>
+            <li><a href="../index.html">Главная</a></li>
+            <li><a href="../services/services.html">Услуги</a></li>
+            <li><a href="about.html">Обо мне</a></li>
+            <li><a href="../index.html#reviews">Отзывы</a></li>
+            <li><a href="../index.html#contacts">Контакты</a></li>
+          </ul>
+        </nav>
+        <a href="tel:+79990000000" class="phone">+7 (999) 000‑00‑00</a>
+      </div>
+    </header>
+
+    <main class="about-page">
+      <section class="about">
+        <div class="container about-wrapper">
+          <img
+            src="https://via.placeholder.com/300x400"
+            alt="Фото адвоката"
+            class="about-photo"
+          />
+          <div class="about-info">
+            <h1>Обо мне</h1>
+            <p>
+              Я — практикующий адвокат с опытом юридической работы более
+              18&nbsp;лет. С&nbsp;декабря 2015&nbsp;года оказываю юридическую
+              помощь в&nbsp;составе коллегии адвокатов, а&nbsp;с 2021&nbsp;года
+              — в&nbsp;собственном адвокатском кабинете. Моя практика охватывает
+              широкий спектр правовых вопросов как для физических, так и для
+              юридических лиц.
+            </p>
+            <h2>Для физических лиц:</h2>
+            <ul>
+              <li>Консультации (устные и&nbsp;письменные)</li>
+              <li>Представительство в&nbsp;государственных органах и&nbsp;судах</li>
+              <li>Подготовка исков, жалоб, ходатайств и&nbsp;других процессуальных документов</li>
+              <li>Ведение дел по&nbsp;гражданским, уголовным и&nbsp;административным спорам</li>
+              <li>Контроль и&nbsp;сопровождение исполнительного производства</li>
+            </ul>
+            <h2>Для юридических лиц:</h2>
+            <ul>
+              <li>Полное юридическое сопровождение деятельности компании (аутсорсинг)</li>
+              <li>Договорная работа (составление, анализ, изменение, расторжение договоров)</li>
+              <li>Сопровождение сделок и&nbsp;регистрация прав на&nbsp;недвижимость</li>
+              <li>Претензионная и&nbsp;судебная работа (арбитражные и&nbsp;иные споры)</li>
+              <li>Разработка внутренних документов компании (положения, приказы, регламенты)</li>
+              <li>Регистрация организаций и&nbsp;ИП, внесение изменений в&nbsp;ЕГРЮЛ/ЕГРИП</li>
+              <li>Подготовка правовых заключений и&nbsp;консультации руководства</li>
+            </ul>
+            <h2>Профессиональный путь:</h2>
+            <ul>
+              <li><strong>С&nbsp;2015&nbsp;года по&nbsp;настоящее время</strong> — адвокат в&nbsp;коллегии адвокатов / адвокатском кабинете</li>
+              <li><strong>2007–2017&nbsp;гг.</strong> — юрист в&nbsp;группе компаний (проектно‑строительная сфера, производство, ЖКХ)</li>
+            </ul>
+            <h2>Образование:</h2>
+            <p>Пермский государственный университет, факультет юриспруденции (2011&nbsp;г.)</p>
+            <h2>Навыки и&nbsp;качества:</h2>
+            <ul>
+              <li>Глубокое знание договорной, судебной и&nbsp;корпоративной практики</li>
+              <li>Ответственность и&nbsp;внимательность к&nbsp;деталям</li>
+              <li>Опыт работы с&nbsp;государственными органами и&nbsp;контролирующими структурами</li>
+            </ul>
+            <p>
+              Работаю в&nbsp;интересах доверителей, всегда выстраиваю стратегию
+              защиты или представительства исходя из&nbsp;конкретной ситуации и
+              целей клиента.
+            </p>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="footer">
+      <div class="container">
+        <p>© 2025 Адвокат Москва. Все права защищены.</p>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@
         <nav class="main-nav">
           <ul>
             <li><a href="services/">Услуги</a></li>
-            <li><a href="#about">Обо мне</a></li>
+            <li><a href="about/about.html">Обо мне</a></li>
             <li><a href="#reviews">Отзывы</a></li>
             <li><a href="#contacts">Контакты</a></li>
           </ul>
@@ -63,24 +63,6 @@
       </div>
     </section>
 
-    <section id="about" class="about">
-      <div class="container about-wrapper">
-        <img
-          src="https://via.placeholder.com/300x400"
-          alt="Фото адвоката"
-          class="about-photo"
-        />
-        <div class="about-info">
-          <h2>Обо мне</h2>
-          <ul class="about-list">
-            <li><span class="about-icon">⚖️</span>Уголовные дела</li>
-            <li><span class="about-icon">👪</span>Семейные дела</li>
-            <li><span class="about-icon">🚗</span>ДТП и автоюрист</li>
-            <li><span class="about-icon">💼</span>Бизнес</li>
-          </ul>
-        </div>
-      </div>
-    </section>
 
     <section id="reviews" class="reviews">
       <div class="container reviews-wrapper">


### PR DESCRIPTION
## Summary
- move expanded About section to a dedicated about/about.html page
- update navigation on the home page to link to the new About page

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c6f344d7f0832980c57af3d009a442