### PR TITLE
Replace sidebar text with logo image

### DIFF
--- a/about/about.html
+++ b/about/about.html
@@ -15,7 +15,7 @@
   <body>
     <header class="top-bar">
       <div class="container">
-        <div class="logo">Адвокат в Москве</div>
+        <div class="logo"><img src="../img/logo.png" alt="Адвокат в Москве" /></div>
         <nav class="main-nav">
           <ul>
             <li><a href="../index.html">Главная</a></li>

--- a/contacts/contacts.html
+++ b/contacts/contacts.html
@@ -15,7 +15,7 @@
   <body>
     <header class="top-bar">
       <div class="container">
-        <div class="logo">Адвокат в Москве</div>
+        <div class="logo"><img src="../img/logo.png" alt="Адвокат в Москве" /></div>
         <nav class="main-nav">
           <ul>
             <li><a href="../index.html">Главная</a></li>

--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@
   <body>
     <header class="top-bar">
       <div class="container">
-        <div class="logo">Адвокат в Москве</div>
+        <div class="logo"><img src="img/logo.png" alt="Адвокат в Москве" /></div>
         <nav class="main-nav">
           <ul>
             <li><a href="index.html">Главная</a></li>

--- a/services/services.html
+++ b/services/services.html
@@ -15,7 +15,7 @@
   <body>
     <header class="top-bar">
       <div class="container">
-        <div class="logo">Адвокат в Москве</div>
+        <div class="logo"><img src="../img/logo.png" alt="Адвокат в Москве" /></div>
         <nav class="main-nav">
           <ul>
             <li><a href="../index.html">Главная</a></li>

--- a/styles.css
+++ b/styles.css
@@ -58,6 +58,10 @@ a {
   font-size: 1.25rem;
 }
 
+.logo img {
+  height: 40px;
+}
+
 .main-nav ul {
   list-style: none;
   display: flex;


### PR DESCRIPTION
## Summary
- show `img/logo.png` in the sidebar instead of the text logo across all pages
- ensure consistent sizing with a `.logo img` rule

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c7246c9cb483298134dc3ac93d108a